### PR TITLE
Vaadin Flow dependencies update due to webpack failure plus minor fixes

### DIFF
--- a/.gradle-wrapper/gradle-wrapper.properties
+++ b/.gradle-wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/cnf/geckoVaadin/geckoVaadinWhiteboard.bnd
+++ b/cnf/geckoVaadin/geckoVaadinWhiteboard.bnd
@@ -17,9 +17,9 @@ vaadin.plugin: \
 -groupid: org.geckoprojects.vaadin
 
 
-geckoVaadinVersion: 0.0.1-SNAPSHOT
+geckoVaadinVersion: 0.0.2-SNAPSHOT
 vaadinVersion: 20.0.0
-flowVersion: 7.0.0
+flowVersion: 7.0.6
 
 vaadinDeps: \
 	com.vaadin:vaadin-accordion-flow:${vaadinVersion},\
@@ -91,7 +91,7 @@ vaadinExtDeps:\
 	biz.aQute.bnd:biz.aQute.bndlib:5.3.0,\
 	org.apache.httpcomponents:httpcore-osgi:4.4.14,\
 	org.apache.httpcomponents:httpclient-osgi:4.5.13,\
-	org.reflections:reflections:0.9.11,\
+	org.reflections:reflections:0.9.12,\
 	org.zeroturnaround:zt-exec:1.12,\
 	com.google.guava:guava:30.1.1-jre,\
 	org.checkerframework:checker-qual:3.14.0,\

--- a/org.gecko.vaadin.generator/bnd.bnd
+++ b/org.gecko.vaadin.generator/bnd.bnd
@@ -1,5 +1,7 @@
 -buildpath: \
 	osgi.annotation;version='7.0.0',\
+	osgi.core;version='7.0.0',\
+	osgi.cmpn;version='7.0.0',\
 	biz.aQute.bndlib,\
 	com.vaadin.flow.plugin.base;version=latest,\
 	com.vaadin.flow.server;version=latest,\

--- a/org.gecko.vaadin.whiteboard.api/bnd.bnd
+++ b/org.gecko.vaadin.whiteboard.api/bnd.bnd
@@ -1,7 +1,7 @@
 -buildpath: \
-	osgi.annotation; version=7.0.0,\
-	osgi.cmpn; version=7.0.0,\
-	osgi.core; version=7.0.0
+	osgi.annotation;version='7.0.0',\
+	osgi.core;version='7.0.0',\
+	osgi.cmpn;version='7.0.0'
 
 -baseline: *
 

--- a/org.gecko.vaadin.whiteboard.demo.frontend/bnd.bnd
+++ b/org.gecko.vaadin.whiteboard.demo.frontend/bnd.bnd
@@ -2,8 +2,8 @@
 	osgi.annotation;version='7.0.0',\
 	osgi.core;version='7.0.0',\
 	osgi.cmpn;version='7.0.0',\
-	org.gecko.vaadin.whiteboard.api;version=project,\
-	org.gecko.vaadin.whiteboard.demo;version=project,\
+	org.gecko.vaadin.whiteboard.api,\
+	org.gecko.vaadin.whiteboard.demo,\
 	com.vaadin.flow.component.button;version=latest,\
 	com.vaadin.flow.component.orderedlayout;version=latest,\
 	com.vaadin.flow.server;version=latest,\
@@ -35,7 +35,7 @@ Bundle-Version: ${geckoVaadinVersion}
 	org.gecko.vaadin.generator,\
 	org.gecko.vaadin.whiteboard,\
 	org.gecko.vaadin.whiteboard.push,\
-	org.gecko.vaadin.demo
+	org.gecko.vaadin.whiteboard.demo
 
 -generate:\
 	test.txt;\
@@ -59,7 +59,7 @@ Bundle-Version: ${geckoVaadinVersion}
 	com.helger.ph-css;version='[6.2.3,6.2.4)',\
 	com.vaadin.external.gentyref;version='[1.2.0,1.2.1)',\
 	com.vaadin.external.gwt;version='[2.8.2,2.8.3)',\
-	com.vaadin.flow.client;version='[7.0.0,7.0.1)',\
+	com.vaadin.flow.client;version='[7.0.6,7.0.7)',\
 	com.vaadin.flow.component.applayout;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.avatar;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.button;version='[20.0.0,20.0.1)',\
@@ -69,10 +69,10 @@ Bundle-Version: ${geckoVaadinVersion}
 	com.vaadin.flow.component.textfield;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.vaadinlumotheme;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.vaadinmaterialtheme;version='[20.0.0,20.0.1)',\
-	com.vaadin.flow.data;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.html.components;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.push;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.server;version='[7.0.0,7.0.1)',\
+	com.vaadin.flow.data;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.html.components;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.push;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.server;version='[7.0.6,7.0.7)',\
 	jakarta.annotation-api;version='[1.3.5,1.3.6)',\
 	net.bytebuddy.byte-buddy;version='[1.10.19,1.10.20)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.2,1.3.3)',\
@@ -81,7 +81,7 @@ Bundle-Version: ${geckoVaadinVersion}
 	org.apache.commons.io;version='[2.5.0,2.5.1)',\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)',\
 	org.apache.felix.configadmin;version='[1.9.18,1.9.19)',\
-	org.apache.felix.configurator;version='[1.0.8,1.0.9)',\
+	org.apache.felix.configurator;version='[1.0.12,1.0.13)',\
 	org.apache.felix.http.bridge;version='[4.1.2,4.1.3)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.24,2.1.25)',\

--- a/org.gecko.vaadin.whiteboard.demo/launch_whiteboard_demo_osgi.bndrun
+++ b/org.gecko.vaadin.whiteboard.demo/launch_whiteboard_demo_osgi.bndrun
@@ -17,7 +17,7 @@
 	com.vaadin.external.atmosphere.runtime;version='[2.4.30,2.4.31)',\
 	com.vaadin.external.gentyref;version='[1.2.0,1.2.1)',\
 	com.vaadin.external.gwt;version='[2.8.2,2.8.3)',\
-	com.vaadin.flow.client;version='[7.0.0,7.0.1)',\
+	com.vaadin.flow.client;version='[7.0.6,7.0.7)',\
 	com.vaadin.flow.component.applayout;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.avatar;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.button;version='[20.0.0,20.0.1)',\
@@ -27,10 +27,10 @@
 	com.vaadin.flow.component.textfield;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.vaadinlumotheme;version='[20.0.0,20.0.1)',\
 	com.vaadin.flow.component.vaadinmaterialtheme;version='[20.0.0,20.0.1)',\
-	com.vaadin.flow.data;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.html.components;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.push;version='[7.0.0,7.0.1)',\
-	com.vaadin.flow.server;version='[7.0.0,7.0.1)',\
+	com.vaadin.flow.data;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.html.components;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.push;version='[7.0.6,7.0.7)',\
+	com.vaadin.flow.server;version='[7.0.6,7.0.7)',\
 	jakarta.activation-api;version='[1.2.2,1.2.3)',\
 	jakarta.annotation-api;version='[1.3.5,1.3.6)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
@@ -41,7 +41,7 @@
 	org.apache.commons.io;version='[2.5.0,2.5.1)',\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)',\
 	org.apache.felix.configadmin;version='[1.9.18,1.9.19)',\
-	org.apache.felix.configurator;version='[1.0.8,1.0.9)',\
+	org.apache.felix.configurator;version='[1.0.12,1.0.13)',\
 	org.apache.felix.http.jetty;version='[4.1.4,4.1.5)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.http.whiteboard;version='[4.0.0,4.0.1)',\


### PR DESCRIPTION
- Update Vaadin Flow Server to version 7.0.6 - this version has 'webpack-cli' and 'workbox' dependencies updated to newer versions which do not cause webpack failure anymore; see comments below for full stack trace and more 
info / background regarding error and fix applied;

- Update transitive dependencies where needed plus minor fixes

Signed-off-by: Michael H. Siemaszko <mhs@into.software>